### PR TITLE
Update Home assistant JS WebSocket to 3.1.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN \
     apk add --no-cache \
      nodejs-current=9.11.1-r2 \
      yarn=1.7.0-r0 \
-     nginx-1.14.0-r1
+     nginx=1.14.0-r1
 
 # Create nginx directories
 RUN mkdir -p /run/nginx && mkdir -p /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN \
     apk add --no-cache \
      nodejs-current=9.11.1-r2 \
      yarn=1.7.0-r0 \
-     nginx=1.14.0-r0
+     nginx-1.14.0-r1
 
 # Create nginx directories
 RUN mkdir -p /run/nginx && mkdir -p /usr/share/nginx/html

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@material-ui/lab": "^3.0.0-alpha.15",
     "@mdi/font": "^2.7.94",
     "classnames": "^2.2.6",
-    "home-assistant-js-websocket": "^3.1.1",
+    "home-assistant-js-websocket": "^3.1.3",
     "is-plain-obj": "^1.1.0",
     "moment": "^2.22.2",
     "prop-types": "^15.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3519,9 +3519,9 @@ hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
 
-home-assistant-js-websocket@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/home-assistant-js-websocket/-/home-assistant-js-websocket-3.1.1.tgz#264f9efdafdff1053294b07bcaa5629e51a22b73"
+home-assistant-js-websocket@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/home-assistant-js-websocket/-/home-assistant-js-websocket-3.1.3.tgz#e66411a7410d6fb35867f008f2d7fc2c394ecb4a"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
# Description

Updates HASS WebSocket to 3.1.3

## Checklist

<!-- Remember! You can check these boxes later after posting your PR -->

- [x] Change has been tested and works on my device(s).
- [x] Linters have been run.<!-- This is handled by the GitLab CI server as preflight checks. Make sure to fix any errors found -->
- [x] I am ready to merge.<!-- You can set the title to 'WIP: My PR' to stop merge early -->
