### PR TITLE
Get name and icon from HA

### DIFF
--- a/src/Components/Cards/Base.tsx
+++ b/src/Components/Cards/Base.tsx
@@ -119,7 +119,9 @@ function Base(props: BaseProps) {
   const cardSize = theme.breakpoints.down('sm') ? 140 : 120;
 
   let height =
-    props.editing === 2 ? 'initial' : props.card.height! * cardSize || cardSize;
+    props.editing === 2 || props.card.type === 'frame'
+      ? 'initial'
+      : props.card.height! * cardSize || cardSize;
   if (props.card.type !== 'entity') height = -1;
   let width =
     props.editing === 2 ? -1 : props.card.width! * cardSize || cardSize;

--- a/src/Components/Configuration/Config.tsx
+++ b/src/Components/Configuration/Config.tsx
@@ -67,6 +67,7 @@ export type CardProps = {
   padding?: number;
   elevation?: number;
   background?: string;
+  icon?: string;
   title?: string;
   content?: string;
   url?: string;

--- a/src/Components/Configuration/EditCard/Base.tsx
+++ b/src/Components/Configuration/EditCard/Base.tsx
@@ -81,7 +81,7 @@ function Base(props: BaseProps) {
               InputLabelProps={{ shrink: true }}
               label="Title"
               placeholder={'Card Title'}
-              defaultValue={props.card.title}
+              value={props.card.title}
               onChange={props.handleChange!('title')}
             />
           </Grid>
@@ -122,7 +122,7 @@ function Base(props: BaseProps) {
             type="number"
             label="Elevation"
             placeholder="1"
-            defaultValue={props.card.elevation}
+            value={props.card.elevation}
             onChange={props.handleChange!('elevation')}
           />
         </Grid>
@@ -132,7 +132,7 @@ function Base(props: BaseProps) {
             InputLabelProps={{ shrink: true }}
             label="Background"
             placeholder="default"
-            defaultValue={props.card.background}
+            value={props.card.background}
             onChange={props.handleChange!('background')}
           />
         </Grid>
@@ -149,7 +149,7 @@ function Base(props: BaseProps) {
             InputLabelProps={{ shrink: true }}
             label="Padding"
             placeholder="12px"
-            defaultValue={props.card.padding}
+            value={props.card.padding}
             onChange={props.handleChange!('padding')}
           />
         </Grid>
@@ -178,7 +178,7 @@ function Base(props: BaseProps) {
             type="number"
             label="Width"
             placeholder="1"
-            defaultValue={props.card.width}
+            value={props.card.width}
             onChange={props.handleChange!('width')}
           />
         </Grid>
@@ -190,7 +190,7 @@ function Base(props: BaseProps) {
               type="number"
               label="Height"
               placeholder="1"
-              defaultValue={props.card.height}
+              value={props.card.height}
               onChange={props.handleChange!('height')}
             />
           </Grid>

--- a/src/Components/Configuration/EditCard/Base.tsx
+++ b/src/Components/Configuration/EditCard/Base.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { makeStyles, Theme } from '@material-ui/core/styles';
+import Button from '@material-ui/core/Button';
 import FormControl from '@material-ui/core/FormControl';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Grid from '@material-ui/core/Grid';
@@ -41,6 +42,7 @@ export interface BaseProps
   extends RouteComponentProps,
     HomeAssistantChangeProps {
   card: CardProps;
+  handleManualChange?: (name: string, value: string) => void;
   handleChange?: (
     name: string
   ) => (event: React.ChangeEvent<HTMLInputElement>) => void;
@@ -53,22 +55,43 @@ export interface BaseProps
 }
 
 function Base(props: BaseProps) {
+  function handleGetEntityTitle() {
+    const entity = props.hassEntities.find(
+      (entity: any) => entity[0] === props.card.entity
+    );
+    if (entity && entity[1].attributes.friendly_name)
+      props.handleManualChange!('title', entity[1].attributes.friendly_name);
+  }
+
   const classes = useStyles();
 
   return (
     <div className={classes.root}>
       <Grid container direction="row" justify="center" alignItems="stretch">
-        <Grid container alignContent="center">
-          <TextField
-            className={classes.textField}
-            InputLabelProps={{ shrink: true }}
-            label="Title"
-            placeholder={'Card Title'}
-            defaultValue={props.card.title}
-            onChange={props.handleChange!('title')}
-          />
+        <Grid
+          container
+          direction="row"
+          justify="center"
+          alignItems="flex-end"
+          item
+          xs>
+          <Grid item xs>
+            <TextField
+              className={classes.textField}
+              InputLabelProps={{ shrink: true }}
+              label="Title"
+              placeholder={'Card Title'}
+              defaultValue={props.card.title}
+              onChange={props.handleChange!('title')}
+            />
+          </Grid>
+          {props.card.type === 'entity' && props.card.entity && (
+            <Grid item>
+              <Button onClick={handleGetEntityTitle}>Get from HA</Button>
+            </Grid>
+          )}
         </Grid>
-        <Grid container alignContent="center">
+        <Grid item container alignContent="center">
           <FormControl className={classes.textField}>
             <InputLabel htmlFor="type">Type</InputLabel>
             <Select
@@ -86,7 +109,12 @@ function Base(props: BaseProps) {
           </FormControl>
         </Grid>
       </Grid>
-      <Grid container direction="row" justify="center" alignItems="stretch">
+      <Grid
+        item
+        container
+        direction="row"
+        justify="center"
+        alignItems="stretch">
         <Grid item xs container justify="flex-start" alignContent="center">
           <TextField
             className={classes.textField}
@@ -109,7 +137,12 @@ function Base(props: BaseProps) {
           />
         </Grid>
       </Grid>
-      <Grid container direction="row" justify="center" alignItems="stretch">
+      <Grid
+        item
+        container
+        direction="row"
+        justify="center"
+        alignItems="stretch">
         <Grid item xs container justify="flex-start" alignContent="center">
           <TextField
             className={classes.textField}
@@ -132,7 +165,12 @@ function Base(props: BaseProps) {
           />
         </Grid>
       </Grid>
-      <Grid container direction="row" justify="center" alignItems="stretch">
+      <Grid
+        item
+        container
+        direction="row"
+        justify="center"
+        alignItems="stretch">
         <Grid item xs container justify="flex-start" alignContent="center">
           <TextField
             className={classes.textField}

--- a/src/Components/Configuration/EditCard/EditCard.tsx
+++ b/src/Components/Configuration/EditCard/EditCard.tsx
@@ -52,6 +52,13 @@ function EditCard(props: EditCardProps) {
     props.handleUpdate(card);
   }
 
+  function handleManualChange(name: string, value: string) {
+    setCard({
+      ...card,
+      [name]: value
+    });
+  }
+
   const handleChange = (name: string) => (
     event: React.ChangeEvent<HTMLInputElement> | string
   ) => {
@@ -106,6 +113,7 @@ function EditCard(props: EditCardProps) {
             <Base
               {...props}
               card={card}
+              handleManualChange={handleManualChange}
               handleChange={handleChange}
               handleSelectChange={handleSelectChange}
               handleSwitchChange={handleSwitchChange}

--- a/src/Components/Configuration/EditCard/Entity.tsx
+++ b/src/Components/Configuration/EditCard/Entity.tsx
@@ -65,7 +65,7 @@ function Entity(props: EntityProps) {
               InputLabelProps={{ shrink: true }}
               label="Icon"
               placeholder="thermometer"
-              defaultValue={props.card.icon}
+              value={props.card.icon}
               onChange={props.handleChange!('icon')}
             />
           </Grid>
@@ -89,7 +89,7 @@ function Entity(props: EntityProps) {
             InputLabelProps={{ shrink: true }}
             label="Entity"
             placeholder="sensor.myamazingsensor"
-            defaultValue={props.card.entity}
+            value={props.card.entity}
             onChange={props.handleChange!('entity')}
           />
         )}

--- a/src/Components/Configuration/EditCard/Entity.tsx
+++ b/src/Components/Configuration/EditCard/Entity.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { makeStyles, Theme } from '@material-ui/core/styles';
+import Button from '@material-ui/core/Button';
 import Grid from '@material-ui/core/Grid';
 import TextField from '@material-ui/core/TextField';
 
@@ -19,10 +20,62 @@ const useStyles = makeStyles((theme: Theme) => ({
 interface EntityProps extends BaseProps {}
 
 function Entity(props: EntityProps) {
+  function handleGetEntityIcon() {
+    const entity = props.hassEntities.find(
+      (entity: any) => entity[0] === props.card.entity
+    );
+    if (entity && entity[1].attributes.icon)
+      props.handleManualChange!(
+        'icon',
+        entity[1].attributes.icon.replace('mdi:', '')
+      );
+  }
+
   const classes = useStyles();
+  const domain = props.card.entity && props.card.entity.split('.')[0].trim();
+
+  let iconAllowed = false;
+  if (
+    domain === 'air_quality' ||
+    domain === 'binary_sensor' ||
+    domain === 'device_tracker' ||
+    domain === 'geo_location' ||
+    domain === 'input_boolean' ||
+    domain === 'light' ||
+    domain === 'remote' ||
+    domain === 'sensor' ||
+    domain === 'sun' ||
+    domain === 'switch'
+  )
+    iconAllowed = true;
 
   return (
-    <Grid container direction="row" justify="center" alignItems="stretch">
+    <Grid container direction="column" justify="center" alignItems="stretch">
+      {iconAllowed && (
+        <Grid
+          container
+          direction="row"
+          justify="center"
+          alignItems="flex-end"
+          item
+          xs>
+          <Grid item xs>
+            <TextField
+              className={classes.textField}
+              InputLabelProps={{ shrink: true }}
+              label="Icon"
+              placeholder="thermometer"
+              defaultValue={props.card.icon}
+              onChange={props.handleChange!('icon')}
+            />
+          </Grid>
+          {props.card.type === 'entity' && props.card.entity && (
+            <Grid item>
+              <Button onClick={handleGetEntityIcon}>Get from HA</Button>
+            </Grid>
+          )}
+        </Grid>
+      )}
       <Grid item xs>
         {props.hassEntities ? (
           <EntitySelect

--- a/src/Components/Configuration/EditCard/Frame.tsx
+++ b/src/Components/Configuration/EditCard/Frame.tsx
@@ -27,7 +27,7 @@ function Frame(props: FrameProps) {
           InputLabelProps={{ shrink: true }}
           label="URL"
           placeholder="https://timmo.dev/home-panel"
-          defaultValue={props.card.url}
+          value={props.card.url}
           onChange={props.handleChange!('url')}
         />
       </Grid>
@@ -37,7 +37,7 @@ function Frame(props: FrameProps) {
           InputLabelProps={{ shrink: true }}
           label="Height"
           placeholder="auto"
-          defaultValue={props.card.height}
+          value={props.card.height}
           onChange={props.handleChange!('height')}
         />
       </Grid>

--- a/src/Components/Configuration/EditCard/Image.tsx
+++ b/src/Components/Configuration/EditCard/Image.tsx
@@ -27,7 +27,7 @@ function Image(props: ImageProps) {
           InputLabelProps={{ shrink: true }}
           label="URL"
           placeholder="https://timmo.dev/home-panel"
-          defaultValue={props.card.url}
+          value={props.card.url}
           onChange={props.handleChange!('url')}
         />
       </Grid>

--- a/src/Components/Configuration/EditCard/Markdown.tsx
+++ b/src/Components/Configuration/EditCard/Markdown.tsx
@@ -28,7 +28,7 @@ function Markdown(props: MarkdownProps) {
           multiline
           label="Content"
           placeholder="- Markdown"
-          defaultValue={props.card.content}
+          value={props.card.content}
           onChange={props.handleChange!('content')}
         />
       </Grid>

--- a/src/Components/HomeAssistant/Cards/State.tsx
+++ b/src/Components/HomeAssistant/Cards/State.tsx
@@ -63,7 +63,11 @@ function State(props: StateProps) {
       <Grid className={classes.iconContainer} item xs={12}>
         {props.card.icon && (
           <Typography
-            className={classnames('mdi', props.card.icon, classes.icon)}
+            className={classnames(
+              'mdi',
+              `mdi-${props.card.icon}`,
+              classes.icon
+            )}
             color="textPrimary"
             variant="h2"
             component="h5"

--- a/src/Components/HomeAssistant/Cards/State.tsx
+++ b/src/Components/HomeAssistant/Cards/State.tsx
@@ -32,7 +32,7 @@ interface StateProps extends EntityProps {}
 
 function State(props: StateProps) {
   const classes = useStyles();
-  let entity: any, state: string | undefined, icon: string | undefined;
+  let entity: any, state: string | undefined;
 
   if (!props.hassEntities) {
     state = 'Home Assistant not connected.';
@@ -49,8 +49,6 @@ function State(props: StateProps) {
     props.card.disabled = false;
     state = properCase(entity[1].state);
     if (entity[1].attributes) {
-      if (entity[1].attributes.icon)
-        icon = entity[1].attributes.icon.replace(':', '-');
       if (entity[1].attributes.unit_of_measurement)
         state += ` ${entity[1].attributes.unit_of_measurement}`;
     }
@@ -63,9 +61,9 @@ function State(props: StateProps) {
       alignContent="center"
       justify="center">
       <Grid className={classes.iconContainer} item xs={12}>
-        {icon && (
+        {props.card.icon && (
           <Typography
-            className={classnames('mdi', icon, classes.icon)}
+            className={classnames('mdi', props.card.icon, classes.icon)}
             color="textPrimary"
             variant="h2"
             component="h5"

--- a/src/Components/HomeAssistant/Cards/Toggle.tsx
+++ b/src/Components/HomeAssistant/Cards/Toggle.tsx
@@ -33,7 +33,7 @@ interface ToggleProps extends EntityProps {}
 function Toggle(props: ToggleProps) {
   const classes = useStyles();
   const theme = useTheme();
-  let entity: any, state: string | undefined, icon: string | undefined;
+  let entity: any, state: string | undefined;
   if (!props.hassEntities) {
     state = 'Home Assistant not connected.';
     props.card.disabled = true;
@@ -56,10 +56,6 @@ function Toggle(props: ToggleProps) {
         : state === 'on'
         ? theme.palette.primary.main
         : theme.palette.background.paper;
-    if (entity[1].attributes) {
-      if (entity[1].attributes.icon)
-        icon = entity[1].attributes.icon.replace(':', '-');
-    }
   }
   return (
     <Grid
@@ -69,9 +65,13 @@ function Toggle(props: ToggleProps) {
       alignContent="center"
       justify="center">
       <Grid className={classes.iconContainer} item xs={12}>
-        {icon && (
+        {props.card.icon && (
           <Typography
-            className={classnames('mdi', icon, classes.icon)}
+            className={classnames(
+              'mdi',
+              `mdi-${props.card.icon}`,
+              classes.icon
+            )}
             color="textPrimary"
             variant="h2"
             component="h5"


### PR DESCRIPTION
# Description

Adds buttons to get data from Home Assistant when editing `entity` card. Also makes icons an option for state and toggle entities

## Checklist

<!-- Remember! You can check these boxes later after posting your PR -->

- [x] Change has been tested and works on my device(s).
- [x] Linters have been run.<!-- This is handled by the GitLab CI server as preflight checks. Make sure to fix any errors found -->
- [x] I am ready to merge.<!-- You can set the title to 'WIP: My PR' to stop merge early -->
