### PR TITLE
Scale image to fit screen

### DIFF
--- a/src/Components/Cards/Image.tsx
+++ b/src/Components/Cards/Image.tsx
@@ -6,16 +6,21 @@ import Dialog from '@material-ui/core/Dialog';
 
 import { BaseProps } from './Base';
 
-const useStyles = makeStyles((_theme: Theme) => ({
+const useStyles = makeStyles((theme: Theme) => ({
   root: {
     height: '100%'
+  },
+  dialogPaper: {
+    background: theme.palette.background.default
   },
   dialog: {
     height: '100%',
     width: '100%'
   },
   image: {
+    height: '100%',
     width: '100%',
+    objectFit: 'scale-down',
     marginBottom: -6,
     cursor: 'pointer'
   }
@@ -40,7 +45,7 @@ function Image(props: ImageProps) {
         alt={props.card.title}
       />
       {dialogOpen && (
-        <Dialog open fullScreen>
+        <Dialog PaperProps={{ className: classes.dialogPaper }} open fullScreen>
           <div className={classes.dialog}>
             <img
               className={classes.image}


### PR DESCRIPTION
# Description

Scales the image component to scale down the image to the screen. Solves scrolling when the image is taller than the screen when at fullscreen.

## Related issues this fixes

Closes #535 

## Checklist

<!-- Remember! You can check these boxes later after posting your PR -->

- [x] Change has been tested and works on my device(s).

<!-- All other checks are handled by the CI server as preflight checks.
     Make sure to fix any errors found.
     Your PR will not be merged if fixable errors are not resolved -->
