### PR TITLE
Fix CardActions button style for Safari

### DIFF
--- a/src/Components/Cards/Base.tsx
+++ b/src/Components/Cards/Base.tsx
@@ -354,6 +354,7 @@ function Base(props: BaseProps) {
               className={classes.cardActions}
               container
               alignContent="center"
+              alignItems="center"
               justify="center">
               <IconButton color="primary" onClick={handleEdit}>
                 <EditIcon fontSize="small" />


### PR DESCRIPTION
# Description
Added `alignItems="center"` seems to fix the issue without regression in Chrome


## Related issues this fixes
#494 

## Screenshots
### Chrome
<img width="780" alt="Screen Shot 2019-10-13 at 10 54 39 PM" src="https://user-images.githubusercontent.com/5971942/66717555-01946a00-ee0d-11e9-8d7a-459c3051e30c.png">

### Safari
<img width="696" alt="Screen Shot 2019-10-13 at 10 54 28 PM" src="https://user-images.githubusercontent.com/5971942/66717557-0822e180-ee0d-11e9-89b0-bef1c97ba1c4.png">


## Checklist

<!-- Remember! You can check these boxes later after posting your PR -->

- [x] Change has been tested and works on my device(s).

<!-- All other checks are handled by the CI server as preflight checks.
     Make sure to fix any errors found.
     Your PR will not be merged if fixable errors are not resolved -->
