### PR TITLE
Fix screen-configuration-theme image

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -25,5 +25,5 @@ From here you can change things like the base, primary color palette,
 
 [screen-configuration-header]: https://raw.githubusercontent.com/timmo001/home-panel/master/docs/resources/screen-configuration-header.png
 [screen-configuration-main]: https://raw.githubusercontent.com/timmo001/home-panel/master/docs/resources/screen-configuration-main.png
-[screen-configuration-theme]: https://raw.githubusercontent.com/timmo001/home-panel/master/docs/resources/screen-configuration-header.gif
+[screen-configuration-theme]: https://raw.githubusercontent.com/timmo001/home-panel/master/docs/resources/screen-configuration-theme.gif
 [css-background-property]: https://www.w3schools.com/cssref/css3_pr_background.asp


### PR DESCRIPTION
# Description
I noticed that the Editing the theme image on [this page ](https://timmo.dev/home-panel/configuration/#editing-the-theme)was not showing up.

Turns out it was a bad url. This PR should fix the issue.

By the way, do you need help with the documentation, I would be more than happy to give a hand.

## Checklist

<!-- Remember! You can check these boxes later after posting your PR -->

- [x] Change has been tested and works on my device(s).

<!-- All other checks are handled by the CI server as preflight checks.
     Make sure to fix any errors found.
     Your PR will not be merged if fixable errors are not resolved -->
