### PR TITLE
Add warning for edit card layout issue in Safari in docs

### DIFF
--- a/docs/docs/configui.md
+++ b/docs/docs/configui.md
@@ -13,6 +13,10 @@ To start editing your UI, click the edit config button in the app bar.
 Enter the Config UI and click on a card's edit button. You can then edit the
 type, name etc. as you like. You can also delete the card if you want.
 
+!!! warning ""
+    If you are running Safari, the editing page might not load correctly.
+     We recommend you use another browser such as Chrome or Fierfox.
+     
 ## Editing a group
 
 Enter the Config UI and click on a group's edit icon. You can then edit the name,


### PR DESCRIPTION
# Description
I noticed that Safari has an issue with properly displaying the editing panel for a card. This issue appears to already have been reported here #672 

Given that it is an external bug, I though it might help new users if we point out this issue on the docs and recommend that they use Chrome or Firefox instead, which both work correctly.

## Checklist

<!-- Remember! You can check these boxes later after posting your PR -->

- [x] Change has been tested and works on my device(s).

<!-- All other checks are handled by the CI server as preflight checks.
     Make sure to fix any errors found.
     Your PR will not be merged if fixable errors are not resolved -->
