### PR TITLE
Update Media.tsx

### DIFF
--- a/src/Components/HomeAssistant/Cards/Media.tsx
+++ b/src/Components/HomeAssistant/Cards/Media.tsx
@@ -164,7 +164,9 @@ function Media(props: MediaProps) {
         attributes.entity_picture && (
           <img
             className={classes.media}
-            src={props.hassAuth.data.hassUrl + attributes.entity_picture}
+            src={(attributes.entity_picture.indexOf("http") === 0)
+                    ? attributes.entity_picture
+                    : (props.hassAuth.data.hassUrl + attributes.entity_picture)}
             alt={attributes.media_title}
           />
         )}


### PR DESCRIPTION
# Description

Updated the Media Component to detect if the Entry Picture is a URL or a Path to an image.

This was causing an issue where the Google Home playing music would show a cover image would point to a YouTube thumbnail URL. Before this update it would prepend the Hassio Address, Causing it to fail. Now it will check to see if it has HTTP in it, if it does then it is a URL address, otherwise, it would assume its a file path.


## Related issues this fixes

No issues found at this moment, but I have attached images that will indicate the issue.

![image](https://user-images.githubusercontent.com/5577816/69017242-aad20100-0973-11ea-9009-81db595d0db0.png)

![image](https://user-images.githubusercontent.com/5577816/69017250-b6bdc300-0973-11ea-809a-cb50324a0737.png)

## Checklist

<!-- Remember! You can check these boxes later after posting your PR -->

- [ ] Change has been tested and works on my device(s).

