### PR TITLE
Add space between state and unit of measurement

### DIFF
--- a/src/Components/HomeAssistant/Cards/State.tsx
+++ b/src/Components/HomeAssistant/Cards/State.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useCallback, ReactElement } from 'react';
 import classnames from 'classnames';
 import moment from 'moment';
 import { HassEntity } from 'home-assistant-js-websocket';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles, Theme } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 
@@ -10,7 +10,7 @@ import { EntityProps } from './Entity';
 import { fetchHistory } from '../Utils/API';
 import Chart, { ChartData } from '../../Visualisations/Chart';
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme: Theme) => ({
   root: {
     flex: 1,
   },
@@ -23,6 +23,9 @@ const useStyles = makeStyles(() => ({
     textAlign: 'center',
     textOverflow: 'ellipsis',
     zIndex: 100,
+  },
+  textSecondary: {
+    marginLeft: theme.spacing(0.5),
   },
   iconContainer: {
     display: 'flex',
@@ -127,10 +130,12 @@ function State(props: EntityProps): ReactElement | null {
           className={classes.text}
           color="textPrimary"
           variant={props.card.disabled ? 'body2' : 'body1'}
-          component="h5"
+          component="span"
           style={{ fontSize: props.card.state_size }}>
           {props.entity.state}
-          {props.entity.attributes.unit_of_measurement}
+          <span className={classes.textSecondary}>
+            {props.entity.attributes.unit_of_measurement}
+          </span>
         </Typography>
       </Grid>
     </Grid>

--- a/src/Components/HomeAssistant/Cards/Weather.tsx
+++ b/src/Components/HomeAssistant/Cards/Weather.tsx
@@ -60,6 +60,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     color: theme.palette.text.primary,
     fontSize: 28,
   },
+  textSecondary: {
+    marginLeft: theme.spacing(0.5),
+  },
 }));
 
 function Weather(props: EntityProps): ReactElement {
@@ -112,7 +115,9 @@ function Weather(props: EntityProps): ReactElement {
             variant="h6"
             noWrap>
             {props.entity.attributes.temperature}
-            {getUnit('temperature', props.hassConfig)}
+            <span className={classes.textSecondary}>
+              {getUnit('temperature', props.hassConfig)}
+            </span>
           </Typography>
         </Grid>
       </Grid>
@@ -167,7 +172,9 @@ function Weather(props: EntityProps): ReactElement {
                       className={classes.forecastText}
                       variant="body2">
                       {w.temperature}
-                      {getUnit('temperature', props.hassConfig)}
+                      <span className={classes.textSecondary}>
+                        {getUnit('temperature', props.hassConfig)}
+                      </span>
                     </Typography>
                     <Typography
                       noWrap


### PR DESCRIPTION
# Description

Adds 4px space between state and unit of measurement

## Related issues this fixes

Closes #1076 

## Checklist

<!-- Remember! You can check these boxes later after posting your PR -->

- [x] Change has been tested and works on my device(s).

<!-- All other checks are handled by the CI server as preflight checks.
     Make sure to fix any errors found.
     Your PR will not be merged if fixable errors are not resolved -->
